### PR TITLE
API spec review

### DIFF
--- a/iothub_client/devdoc/iothubclient_c_library.md
+++ b/iothub_client/devdoc/iothubclient_c_library.md
@@ -475,29 +475,52 @@ By default messages never expire. The meaning of the messageTimeout value is the
     - 0 = disable message timeout for all messages send by _SendAsync from now on
     - Any other number - consider that number as the timeout.
 - "x509certificate" - feeds a x509 certificate in PEM format to IoTHubClient to be used for 
-authentication. value is a pointer to a null terminated string that contains the certificate. Example:
+authentication. value is a pointer to a null terminated string that contains the certificate. Important: certain TLS stacks are sensitive to line terminators. Example:
 ```c
 const char* value =
-"-----BEGIN CERTIFICATE-----"
-"MIICpDCCAYwCCQCfIjBnPxs5TzANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls"
-"b2NhbGhvc3QwHhcNMTYwNjIyMjM0MzI3WhcNMTYwNjIzMjM0MzI3WjAUMRIwEAYD"
+"-----BEGIN CERTIFICATE-----\n"
+"MIICpDCCAYwCCQCfIjBnPxs5TzANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAls\n"
+"b2NhbGhvc3QwHhcNMTYwNjIyMjM0MzI3WhcNMTYwNjIzMjM0MzI3WjAUMRIwEAYD\n"
 ...
-"+s88wBF907s1dcY45vsG0ldE3f7Y6anGF60nUwYao/fN/eb5FT5EHANVMmnK8zZ2"
-"tjWUt5TFnAveFoQWIoIbtzlTbOxUFwMrQFzFXOrZoDJmHNWc2u6FmVAkowoOSHiE"
-"dkyVdoGPCXc="
-"-----END CERTIFICATE-----";
+"+s88wBF907s1dcY45vsG0ldE3f7Y6anGF60nUwYao/fN/eb5FT5EHANVMmnK8zZ2\n"
+"tjWUt5TFnAveFoQWIoIbtzlTbOxUFwMrQFzFXOrZoDJmHNWc2u6FmVAkowoOSHiE\n"
+"dkyVdoGPCXc=\n"
+"-----END CERTIFICATE-----\n";
 ```
-- "x509privatekey" - feed a x509 private key in PEM format to IoTHubClient to be used for authentication. value is a pointer to a null terminated string that contains the key. Example:
+- "x509privatekey" - feed a x509 private key in PEM format to IoTHubClient to be used for authentication. value is a pointer to a null terminated string that contains the key. Important: certain TLS stacks are sensitive to line terminators. Example:
 ```c
 const char* privateKey = 
-"-----BEGIN RSA PRIVATE KEY-----"            
-"MIIEpQIBAAKCAQEA0zKK+Uu5I0nXq2V6+2gbdCsBXZ6j1uAgU/clsCohEAek1T8v"
-"qj2tR9Mz9iy9RtXPMHwzcQ7aXDaz7RbHdw7tYXqSw8iq0Mxq2s3p4mo6gd5vEOiN"
+"-----BEGIN RSA PRIVATE KEY-----\n"            
+"MIIEpQIBAAKCAQEA0zKK+Uu5I0nXq2V6+2gbdCsBXZ6j1uAgU/clsCohEAek1T8v\n"
+"qj2tR9Mz9iy9RtXPMHwzcQ7aXDaz7RbHdw7tYXqSw8iq0Mxq2s3p4mo6gd5vEOiN\n"
 ...
-"EyePNmkCgYEAng+12qvs0de7OhkTjX9FLxluLWxfN2vbtQCWXslLCG+Es/ZzGlNF"
-"SaqVID4EAUgUqFDw0UO6SKLT+HyFjOr5qdHkfAmRzwE/0RBN69g2qLDN3Km1Px/k"
-"xyJyxc700uV1eKiCdRLRuCbUeecOSZreh8YRIQQXoG8uotO5IttdVRc="        
-"-----END RSA PRIVATE KEY-----";
+"EyePNmkCgYEAng+12qvs0de7OhkTjX9FLxluLWxfN2vbtQCWXslLCG+Es/ZzGlNF\n"
+"SaqVID4EAUgUqFDw0UO6SKLT+HyFjOr5qdHkfAmRzwE/0RBN69g2qLDN3Km1Px/k\n"
+"xyJyxc700uV1eKiCdRLRuCbUeecOSZreh8YRIQQXoG8uotO5IttdVRc=\n"        
+"-----END RSA PRIVATE KEY-----\n";
+```
+
+- "OPENSSLOPT_ENGINE" - only available when OpenSSL is used. It specifies the [OpenSSL built-in engine](https://www.openssl.org/docs/man1.1.1/man3/ENGINE_load_builtin_engines.html) to be loaded. This option changes the meaning of the `x509privatekey` option to be used as the key identifier. value is a null terminated string that contains the engine name. Examples:
+```c
+// Example using Azure IoT Key Service
+const char* openssl_engine = "aziot_keys";
+const char* privateKey = "<key_handle>"; // Replace with assigned key handle.
+```
+
+```c
+// Example using TPM TSS OpenSSL ENGINE
+const char* openssl_engine = "tpm2tss";
+// When the TPM2TSS engine is used, the key identifier is a path to a PEM-encoded TSS2 private key:
+const char* privateKey = "/home/restricted_user/tpm2ec.tss"
+```
+
+- __[[DESIGN QUESTION]]__ "OPENSSLOPT_UI_METHOD" - only available when OpenSSL is used. It specifies the [OpenSSL UI_METHOD](https://www.openssl.org/docs/man1.1.1/man3/UI_new_method.html) used to prompt and read passwords required to access the private key for ENGINE private keys (__[[DESIGN QUESTION]]__ and for encrypted PEM files.). Example:
+
+```c
+#include <openssl/ui.h>
+
+static UI_METHOD *ui_method;
+// initialize ui_method (see https://github.com/openssl/openssl/blob/master/apps/lib/apps_ui.c#L115 for an example)
 ```
 
 ## IotHubClient\_LL\_... APIs

--- a/iothub_client/devdoc/iothubclient_c_library.md
+++ b/iothub_client/devdoc/iothubclient_c_library.md
@@ -501,9 +501,9 @@ const char* x509privatekey =
 ```
 
 - "CypherSuite" - only available when OpenSSL is used. value is a pointer to a null terminated string that contains a list in the format specified by [SSL_set_cipher_list](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_cipher_list.html).
-- "Engine" - only available when OpenSSL is used. It specifies the [OpenSSL built-in engine](https://www.openssl.org/docs/man1.1.1/man3/ENGINE_load_builtin_engines.html) to be loaded. This option changes the meaning of the `x509certificate` and `x509privatekey` options to be used as the certificate identifier and key identifier respectively. value is a null terminated string that contains the engine name.
-- "x509CertificateType" - only available when OpenSSL is used and OPENSSLOPT_ENGINE is configured. value is a pointer to a long. When set to 0x1, the public key is loaded using the OpenSSL Engine. The `x509certificate` option represents the engine-specific certificate identifier. Defaults to PEM string.
-- "x509PrivatekeyType" - only available when OpenSSL is used and OPENSSLOPT_ENGINE is configured. value is a pointer to a long. When set to 0x1, the private key is loaded from the OpenSSL Engine. The `x509privatekey` option represents the engine-specific certificate identifier. Defaults to PEM string.
+- "Engine" - only available when OpenSSL is used. It specifies the [OpenSSL built-in engine](https://www.openssl.org/docs/man1.1.1/man3/ENGINE_load_builtin_engines.html) to be loaded. value is a null terminated string that contains the engine name.
+- "x509CertificateType" - only available when OpenSSL is used and OPENSSLOPT_ENGINE is configured. value is a pointer to a long. When set to 0x1, the public key is loaded using the OpenSSL Engine. The `x509certificate` option represents the engine-specific certificate identifier.
+- "x509PrivatekeyType" - only available when OpenSSL is used and OPENSSLOPT_ENGINE is configured. value is a pointer to a long. When set to 0x1, the private key is loaded from the OpenSSL Engine. The `x509privatekey` option represents the engine-specific certificate identifier.
 
 OpenSSL ENGINE Examples:
 ```c

--- a/iothub_client/devdoc/iothubclient_c_library.md
+++ b/iothub_client/devdoc/iothubclient_c_library.md
@@ -489,7 +489,7 @@ const char* value =
 ```
 - "x509privatekey" - feed a x509 private key in PEM format to IoTHubClient to be used for authentication. value is a pointer to a null terminated string that contains the key. Important: certain TLS stacks are sensitive to line terminators. Example:
 ```c
-const char* privateKey = 
+const char* x509privatekey = 
 "-----BEGIN RSA PRIVATE KEY-----\n"            
 "MIIEpQIBAAKCAQEA0zKK+Uu5I0nXq2V6+2gbdCsBXZ6j1uAgU/clsCohEAek1T8v\n"
 "qj2tR9Mz9iy9RtXPMHwzcQ7aXDaz7RbHdw7tYXqSw8iq0Mxq2s3p4mo6gd5vEOiN\n"
@@ -500,22 +500,35 @@ const char* privateKey =
 "-----END RSA PRIVATE KEY-----\n";
 ```
 
-- "OPENSSLOPT_ENGINE" - only available when OpenSSL is used. It specifies the [OpenSSL built-in engine](https://www.openssl.org/docs/man1.1.1/man3/ENGINE_load_builtin_engines.html) to be loaded. This option changes the meaning of the `x509certificate` and `x509privatekey` options to be used as the certificate identifier and key identifier respectively. value is a null terminated string that contains the engine name.
-- "OPENSSLOPT_ENGINE_CERT_TYPE" - only available when OpenSSL is used and OPENSSLOPT_ENGINE is configured. value is a pointer to a long. When set to 0x1, the public key is loaded using the OpenSSL Engine. The `x509certificate` option represents the engine-specific certificate identifier.
-- "OPENSSLOPT_ENGINE_KEY_TYPE" - only available when OpenSSL is used and OPENSSLOPT_ENGINE is configured. value is a pointer to a long. When set to 0x1, the private key is loaded from the OpenSSL Engine. The `x509privatekey` option represents the engine-specific certificate identifier.
+- "CypherSuite" - only available when OpenSSL is used. value is a pointer to a null terminated string that contains a list in the format specified by [SSL_set_cipher_list](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_cipher_list.html).
+- "Engine" - only available when OpenSSL is used. It specifies the [OpenSSL built-in engine](https://www.openssl.org/docs/man1.1.1/man3/ENGINE_load_builtin_engines.html) to be loaded. This option changes the meaning of the `x509certificate` and `x509privatekey` options to be used as the certificate identifier and key identifier respectively. value is a null terminated string that contains the engine name.
+- "x509CertificateType" - only available when OpenSSL is used and OPENSSLOPT_ENGINE is configured. value is a pointer to a long. When set to 0x1, the public key is loaded using the OpenSSL Engine. The `x509certificate` option represents the engine-specific certificate identifier. Defaults to PEM string.
+- "x509PrivatekeyType" - only available when OpenSSL is used and OPENSSLOPT_ENGINE is configured. value is a pointer to a long. When set to 0x1, the private key is loaded from the OpenSSL Engine. The `x509privatekey` option represents the engine-specific certificate identifier. Defaults to PEM string.
 
 OpenSSL ENGINE Examples:
 ```c
 // Example using Azure IoT Identity, Key and Certificate Services
 const char* openssl_engine = "aziot_keys";
-const char* privateKey = "<key_handle>"; // Replace with assigned key handle.
+const char* x509privatekey = "<key_handle>"; // Replace with assigned key handle.
+const long x509privatekeytype = 1;
 ```
 
 ```c
 // Example using TPM TSS OpenSSL ENGINE
 const char* openssl_engine = "tpm2tss";
+
+// When the TPM2TSS engine is used, the public certificate is loaded from a PEM string.
+const char* x509certificate =
+"-----BEGIN CERTIFICATE-----\n"
+"MIIBJTCBywIUUennAV2WbZsckSIcMHLXuak/iCswCgYIKoZIzj0EAwIwFTETMBEG\n"
+// [...]
+"OkZcAK4VBLwYnoH+glXK6pWqDkXE0wIhAM0OFOTbVIuXOGDXaCKxFLIvMifo2RJZ\n"
+"b5pjgB2gaGGi\n"
+"-----END CERTIFICATE-----\n";
+
 // When the TPM2TSS engine is used, the key identifier is a path to a PEM-encoded TSS2 private key:
-const char* privateKey = "/home/restricted_user/tpm2ec.tss"
+const long x509privatekeytype = 1;
+const char* x509privatekey = "/home/restricted_user/tpm2ec.tss"
 ```
 
 ```c

--- a/iothub_client/devdoc/iothubclient_c_library.md
+++ b/iothub_client/devdoc/iothubclient_c_library.md
@@ -500,9 +500,13 @@ const char* privateKey =
 "-----END RSA PRIVATE KEY-----\n";
 ```
 
-- "OPENSSLOPT_ENGINE" - only available when OpenSSL is used. It specifies the [OpenSSL built-in engine](https://www.openssl.org/docs/man1.1.1/man3/ENGINE_load_builtin_engines.html) to be loaded. This option changes the meaning of the `x509privatekey` option to be used as the key identifier. value is a null terminated string that contains the engine name. Examples:
+- "OPENSSLOPT_ENGINE" - only available when OpenSSL is used. It specifies the [OpenSSL built-in engine](https://www.openssl.org/docs/man1.1.1/man3/ENGINE_load_builtin_engines.html) to be loaded. This option changes the meaning of the `x509certificate` and `x509privatekey` options to be used as the certificate identifier and key identifier respectively. value is a null terminated string that contains the engine name.
+- "OPENSSLOPT_ENGINE_CERT_TYPE" - only available when OpenSSL is used and OPENSSLOPT_ENGINE is configured. value is a pointer to a long. When set to 0x1, the public key is loaded using the OpenSSL Engine. The `x509certificate` option represents the engine-specific certificate identifier.
+- "OPENSSLOPT_ENGINE_KEY_TYPE" - only available when OpenSSL is used and OPENSSLOPT_ENGINE is configured. value is a pointer to a long. When set to 0x1, the private key is loaded from the OpenSSL Engine. The `x509privatekey` option represents the engine-specific certificate identifier.
+
+OpenSSL ENGINE Examples:
 ```c
-// Example using Azure IoT Key Service
+// Example using Azure IoT Identity, Key and Certificate Services
 const char* openssl_engine = "aziot_keys";
 const char* privateKey = "<key_handle>"; // Replace with assigned key handle.
 ```
@@ -513,8 +517,6 @@ const char* openssl_engine = "tpm2tss";
 // When the TPM2TSS engine is used, the key identifier is a path to a PEM-encoded TSS2 private key:
 const char* privateKey = "/home/restricted_user/tpm2ec.tss"
 ```
-
-- __[[DESIGN QUESTION]]__ "OPENSSLOPT_UI_METHOD" - only available when OpenSSL is used. It specifies the [OpenSSL UI_METHOD](https://www.openssl.org/docs/man1.1.1/man3/UI_new_method.html) used to prompt and read passwords required to access the private key for ENGINE private keys (__[[DESIGN QUESTION]]__ and for encrypted PEM files.). Example:
 
 ```c
 #include <openssl/ui.h>

--- a/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
+++ b/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
@@ -55,6 +55,7 @@ and removing calls to _DoWork will yield the same results. */
 /*  "HostName=<host_name>;DeviceId=<device_id>;x509=true"                      */
 static const char* connectionString = "HostName=crispop-iothub1.azure-devices.net;DeviceId=tpm2engine;x509=true";
 
+static const char* opensslEngine = "tpm2tss";
 static const char* x509certificate =
 "-----BEGIN CERTIFICATE-----\n"
 "MIIBJTCBywIUUennAV2WbZsckSIcMHLXuak/iCswCgYIKoZIzj0EAwIwFTETMBEG\n"
@@ -67,6 +68,7 @@ static const char* x509certificate =
 "-----END CERTIFICATE-----\n";
 
 static const char* x509privatekey = "/home/cristian/cert/tpm2ec.tss";
+static const OPTION_OPENSSL_KEY_TYPE x509keyengine = KEY_TYPE_ENGINE;
 
 #define MESSAGE_COUNT        5
 static bool g_continueRunning = true;
@@ -137,8 +139,11 @@ int main(void)
 
         // Set the X509 certificates in the SDK
         if (
+            (IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_OPENSSL_ENGINE, opensslEngine) != IOTHUB_CLIENT_OK) ||
             (IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_X509_CERT, x509certificate) != IOTHUB_CLIENT_OK) ||
-            (IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_X509_PRIVATE_KEY, x509privatekey) != IOTHUB_CLIENT_OK)
+            (IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_X509_PRIVATE_KEY, x509privatekey) != IOTHUB_CLIENT_OK) || 
+            //(IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_OPENSSL_CERT_TYPE, &x509keyengine) != IOTHUB_CLIENT_OK) || 
+            (IoTHubDeviceClient_LL_SetOption(device_ll_handle, OPTION_OPENSSL_PRIVATE_KEY_TYPE, &x509keyengine) != IOTHUB_CLIENT_OK)
             )
         {
             printf("failure to set options for x509, aborting\r\n");

--- a/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
+++ b/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
@@ -51,6 +51,12 @@ and removing calls to _DoWork will yield the same results. */
     #include "certs.h"
 #endif // SET_TRUSTED_CERT_IN_SAMPLES
 
+
+//#define TPM2TSS
+#define ISKS
+//#define ISKS_DIRECT
+
+#ifdef TPM2TSS
 /* Paste in the your x509 iothub connection string  */
 /*  "HostName=<host_name>;DeviceId=<device_id>;x509=true"                      */
 static const char* connectionString = "HostName=crispop-iothub1.azure-devices.net;DeviceId=tpm2engine;x509=true";
@@ -69,6 +75,34 @@ static const char* x509certificate =
 
 static const char* x509privatekey = "/home/cristian/cert/tpm2ec.tss";
 static const OPTION_OPENSSL_KEY_TYPE x509keyengine = KEY_TYPE_ENGINE;
+#endif
+
+#ifdef ISKS
+/* Paste in the your x509 iothub connection string  */
+/*  "HostName=<host_name>;DeviceId=<device_id>;x509=true"                      */
+static const char* connectionString = "HostName=crispop-iothub1.azure-devices.net;DeviceId=iot-key-service1;x509=true";
+
+static const char* opensslEngine = "aziotkeys";
+static const char* x509certificate = 
+"-----BEGIN CERTIFICATE-----\n"
+"MIIBMTCB1wIUTu66kxJIBR5t5IkAwh7Lqm/AM+IwCgYIKoZIzj0EAwIwGzEZMBcG\n"
+"A1UEAwwQaW90LWtleS1zZXJ2aWNlMTAeFw0yMDEwMzAwMDQwMTZaFw0yMTEwMzAw\n"
+"MDQwMTZaMBsxGTAXBgNVBAMMEGlvdC1rZXktc2VydmljZTEwWTATBgcqhkjOPQIB\n"
+"BggqhkjOPQMBBwNCAARuUKXqZvNDCOhqdRMhOluD5xpm00E5arOXbqrqrCrOhjT4\n"
+"7o3NamR9UPuC3Nbp9qTckzcQMoWPu9hgGkbniBN0MAoGCCqGSM49BAMCA0kAMEYC\n"
+"IQC2hvx3haS3kxpIQzrzsKKpWlAGed0z7dn2HOY4x5bzlwIhAKyYtxbF62laYahF\n"
+"DItkq1MHqzqExB1eTrMHQVY11w62\n"
+"-----END CERTIFICATE-----\n";
+
+static const char* x509privatekey = "sr=eyJrZXlfaWQiOnsiS2V5UGFpciI6ImRldmljZS1pZCJ9LCJub25jZSI6IlQ2eWo3cE0vMHY5anAyNm5qL2NFWUdNZjFTL2lSRGdKMnpEeWpoNkQycE52S0FhdStEdGNhNXNkd2dWbGZKaVlkbHJKeG5wOE1XdmpDcnhmd1A4eHhRPT0ifQ==&sig=wITb99HtU/zGwtvKYW6dlkjtPK2ljVqUjmC9gqvZTmw=";
+
+static const OPTION_OPENSSL_KEY_TYPE x509keyengine = KEY_TYPE_ENGINE;
+#endif
+
+#ifdef ISKS_DIRECT
+
+
+#endif
 
 #define MESSAGE_COUNT        5
 static bool g_continueRunning = true;


### PR DESCRIPTION
1. Adding one new IoTHub Device Client option to support OpenSSL Engines.
2. Question around allowing another option to allow external UI (or input methods) for specifying passwords.

