### PR TITLE
Adding PKCS#11 test, refactoring Engine object lifetimes

### DIFF
--- a/iothub_client/devdoc/iothubclient_c_library.md
+++ b/iothub_client/devdoc/iothubclient_c_library.md
@@ -502,14 +502,13 @@ const char* x509privatekey =
 
 - "CypherSuite" - only available when OpenSSL is used. value is a pointer to a null terminated string that contains a list in the format specified by [SSL_set_cipher_list](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_cipher_list.html).
 - "Engine" - only available when OpenSSL is used. It specifies the [OpenSSL built-in engine](https://www.openssl.org/docs/man1.1.1/man3/ENGINE_load_builtin_engines.html) to be loaded. value is a null terminated string that contains the engine name.
-- "x509CertificateType" - only available when OpenSSL is used and OPENSSLOPT_ENGINE is configured. value is a pointer to a long. When set to 0x1, the public key is loaded using the OpenSSL Engine. The `x509certificate` option represents the engine-specific certificate identifier.
 - "x509PrivatekeyType" - only available when OpenSSL is used and OPENSSLOPT_ENGINE is configured. value is a pointer to a long. When set to 0x1, the private key is loaded from the OpenSSL Engine. The `x509privatekey` option represents the engine-specific certificate identifier.
 
 OpenSSL ENGINE Examples:
 ```c
 // Example using Azure IoT Identity, Key and Certificate Services
 const char* openssl_engine = "aziot_keys";
-const char* x509privatekey = "<key_handle>"; // Replace with assigned key handle.
+const char* x509privatekey = "sr=eyJrZXlfaWQiOnsiS2V5UGFpciI6ImRldmljZS...zGwtvKYW6dlkjtPK2ljVqUjmC9gqvZTmw=""; // Replace with assigned key handle.
 const long x509privatekeytype = 1;
 ```
 
@@ -532,10 +531,17 @@ const char* x509privatekey = "/home/restricted_user/tpm2ec.tss"
 ```
 
 ```c
-#include <openssl/ui.h>
+// Example using PKCS#11 OpenSSL ENGINE
+static const char* opensslEngine = "pkcs11";
+static const char* x509certificate = 
+"-----BEGIN CERTIFICATE-----\n"
+"MIIBMTCB1wIUTu66kxJIBR5t5IkAwh7Lqm/AM+IwCgYIKoZIzj0EAwIwGzEZMBcG\n"
+// [...]
+"DItkq1MHqzqExB1eTrMHQVY11w62\n"
+"-----END CERTIFICATE-----\n";
 
-static UI_METHOD *ui_method;
-// initialize ui_method (see https://github.com/openssl/openssl/blob/master/apps/lib/apps_ui.c#L115 for an example)
+static const char* x509privatekey = "pkcs11:object=ec-privkey;type=private?pin-value=1234";
+static const OPTION_OPENSSL_KEY_TYPE x509keyengine = KEY_TYPE_ENGINE;
 ```
 
 ## IotHubClient\_LL\_... APIs

--- a/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
+++ b/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
@@ -53,8 +53,8 @@ and removing calls to _DoWork will yield the same results. */
 
 
 //#define TPM2TSS
-//#define ISKS
-#define PKCS11
+#define ISKS
+//#define PKCS11
 
 #ifdef TPM2TSS
 /* Paste in the your x509 iothub connection string  */
@@ -83,7 +83,7 @@ static const OPTION_OPENSSL_KEY_TYPE x509keyengine = KEY_TYPE_ENGINE;
 static const char* connectionString = "HostName=crispop-iothub1.azure-devices.net;DeviceId=iot-key-service1;x509=true";
 
 static const char* opensslEngine = "aziot_keys";
-static const char* x509certificate = 
+static const char* x509certificate =
 "-----BEGIN CERTIFICATE-----\n"
 "MIIBMTCB1wIUTu66kxJIBR5t5IkAwh7Lqm/AM+IwCgYIKoZIzj0EAwIwGzEZMBcG\n"
 "A1UEAwwQaW90LWtleS1zZXJ2aWNlMTAeFw0yMDEwMzAwMDQwMTZaFw0yMTEwMzAw\n"
@@ -105,7 +105,7 @@ static const OPTION_OPENSSL_KEY_TYPE x509keyengine = KEY_TYPE_ENGINE;
 static const char* connectionString = "HostName=crispop-iothub1.azure-devices.net;DeviceId=iot-key-service1;x509=true";
 
 static const char* opensslEngine = "pkcs11";
-static const char* x509certificate = 
+static const char* x509certificate =
 "-----BEGIN CERTIFICATE-----\n"
 "MIIBMTCB1wIUTu66kxJIBR5t5IkAwh7Lqm/AM+IwCgYIKoZIzj0EAwIwGzEZMBcG\n"
 "A1UEAwwQaW90LWtleS1zZXJ2aWNlMTAeFw0yMDEwMzAwMDQwMTZaFw0yMTEwMzAw\n"

--- a/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
+++ b/iothub_client/samples/iothub_ll_client_x509_sample/iothub_ll_client_x509_sample.c
@@ -53,8 +53,8 @@ and removing calls to _DoWork will yield the same results. */
 
 
 //#define TPM2TSS
-#define ISKS
-//#define ISKS_DIRECT
+//#define ISKS
+#define PKCS11
 
 #ifdef TPM2TSS
 /* Paste in the your x509 iothub connection string  */
@@ -99,9 +99,26 @@ static const char* x509privatekey = "sr=eyJrZXlfaWQiOnsiS2V5UGFpciI6ImRldmljZS1p
 static const OPTION_OPENSSL_KEY_TYPE x509keyengine = KEY_TYPE_ENGINE;
 #endif
 
-#ifdef ISKS_DIRECT
+#ifdef PKCS11
+/* Paste in the your x509 iothub connection string  */
+/*  "HostName=<host_name>;DeviceId=<device_id>;x509=true"                      */
+static const char* connectionString = "HostName=crispop-iothub1.azure-devices.net;DeviceId=iot-key-service1;x509=true";
 
+static const char* opensslEngine = "pkcs11";
+static const char* x509certificate = 
+"-----BEGIN CERTIFICATE-----\n"
+"MIIBMTCB1wIUTu66kxJIBR5t5IkAwh7Lqm/AM+IwCgYIKoZIzj0EAwIwGzEZMBcG\n"
+"A1UEAwwQaW90LWtleS1zZXJ2aWNlMTAeFw0yMDEwMzAwMDQwMTZaFw0yMTEwMzAw\n"
+"MDQwMTZaMBsxGTAXBgNVBAMMEGlvdC1rZXktc2VydmljZTEwWTATBgcqhkjOPQIB\n"
+"BggqhkjOPQMBBwNCAARuUKXqZvNDCOhqdRMhOluD5xpm00E5arOXbqrqrCrOhjT4\n"
+"7o3NamR9UPuC3Nbp9qTckzcQMoWPu9hgGkbniBN0MAoGCCqGSM49BAMCA0kAMEYC\n"
+"IQC2hvx3haS3kxpIQzrzsKKpWlAGed0z7dn2HOY4x5bzlwIhAKyYtxbF62laYahF\n"
+"DItkq1MHqzqExB1eTrMHQVY11w62\n"
+"-----END CERTIFICATE-----\n";
 
+static const char* x509privatekey = "pkcs11:object=ec-privkey;type=private?pin-value=1234";
+
+static const OPTION_OPENSSL_KEY_TYPE x509keyengine = KEY_TYPE_ENGINE;
 #endif
 
 #define MESSAGE_COUNT        5


### PR DESCRIPTION
- PKCS#11 test, including reconnect, invalid PIN
- TPMv2 test, including reconnect
- IS/KS test

KS Engine known failure on `ENGINE_remove()`.